### PR TITLE
Use fingerprint instead of id for gpg key

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,7 +15,7 @@
   when: ansible_os_family == "RedHat"
 
 - name: Add packagecloud.io GPG key to apt-key
-  apt_key: id=D59097AB url=https://packagecloud.io/gpg.key state=present
+  apt_key: id=418A7F2FB0E1E6E7EABF6FE8C2E73424D59097AB url=https://packagecloud.io/gpg.key state=present
   when: ansible_os_family == "Debian"
 
 - name: "Adding packagecloud.io repository: {{ repository }}"


### PR DESCRIPTION
GPG short ids are vulnerable to collisions (eg https://evil32.com/ , http://security.stackexchange.com/questions/74009/what-is-an-openpgp-key-id-collision). I believe it is _much_ harder to create a full fingerprint collision.

We can specify the full fingerprint instead of the key id in order to mitigate an attacker that can MiTM the gpg key provided by packagecloud.

I understand that the key is served over SSL. After this patch, our trust in packagecloud is now stronger than our trust in the SSL connection to packagecloud.io.
